### PR TITLE
The README.md code breaks with store undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ function changeCount(state = { count: 0 }, action) {
 
 function render() {
   let container = document.getElementById('container');
-  container.textContent = store.getState.count;
+  if(!!store) container.textContent = store.getState().count;
 };
 
 let store = createStore(changeCount) // createStore takes the changeCount reducer as an argument


### PR DESCRIPTION
`render()` is called from  `dispatch({ type: '@@INIT' })` on line 189 of this README.md or line 33 in the project code of `reducer.js` (`container.textContent = store.getState.count`), before store is defined, so you get a undefined `store` error. So you need to place a `if` statement to catch it if it's empty. Also `getState` was changed to invoke, `getState()`. So the complete change is just `if(!!store) container.textContent = store.getState().count;`